### PR TITLE
Fix project library import issue

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -16,5 +16,5 @@ android {
 
 dependencies {
     compile fileTree(include: ['*.jar'], dir: 'libs')
-    compile project(':parallaxrecyclerview')
+    compile 'com.github.kanytu:android-parallax-recyclerview:v1.2'
 }

--- a/app/src/main/java/com/poliveira/apps/exampleparallaxrecycler/MainActivity.java
+++ b/app/src/main/java/com/poliveira/apps/exampleparallaxrecycler/MainActivity.java
@@ -8,7 +8,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
-import com.poliveira.parallaxrecyclerview.adapter.ParallaxRecyclerAdapter;
+import com.poliveira.parallaxrecycleradapter.ParallaxRecyclerAdapter;
 
 import java.util.ArrayList;
 import java.util.List;

--- a/build.gradle
+++ b/build.gradle
@@ -15,5 +15,8 @@ buildscript {
 allprojects {
     repositories {
         jcenter()
+        maven {
+            url "https://jitpack.io"
+        }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,1 @@
 include ':app', ':parallaxrecyclerview'
-project(":parallaxrecyclerview").projectDir = file("E:\\Development\\android\\MyApplication3\\parallaxrecyclerview")


### PR DESCRIPTION
There were issues importing the example project due to the gradle settings being tied to the original developer's library location. Currently importing the library as a typical dev using the library would.
